### PR TITLE
Decouple switches from encoding

### DIFF
--- a/imagewriter/encoding/motion.py
+++ b/imagewriter/encoding/motion.py
@@ -1,5 +1,4 @@
-import dataclasses
-from typing import List, Self, Sequence, Tuple, Type
+from typing import List, Self, Sequence, Type
 
 from imagewriter.encoding.base import (
     Bytes,
@@ -13,7 +12,6 @@ from imagewriter.encoding.base import (
 from imagewriter.encoding.switch import (
     CloseSoftwareSwitches,
     OpenSoftwareSwitches,
-    SoftwareSwitches,
 )
 from imagewriter.motion import LinesPerInch
 from imagewriter.pitch import Pitch
@@ -197,9 +195,7 @@ class LineFeedEncoder:
         return Esc("r")
 
     @classmethod
-    def set_auto_after_cr(
-        cls: Type[Self], settings: SoftwareSwitches, enabled: bool
-    ) -> Tuple[SoftwareSwitches, Command]:
+    def set_auto_after_cr(cls: Type[Self], enabled: bool) -> Command:
         """
         Enable or disable an automatic LF after a CR, as per page 34 of the
         ImageWriter II Technical Reference Manual.
@@ -207,15 +203,10 @@ class LineFeedEncoder:
 
         cmd_cls = CloseSoftwareSwitches if enabled else OpenSoftwareSwitches
 
-        return (
-            dataclasses.replace(settings, auto_lf_after_cr=enabled),
-            cmd_cls({SoftwareSwitch.AUTO_LF_AFTER_CR}),
-        )
+        return cmd_cls({SoftwareSwitch.AUTO_LF_AFTER_CR})
 
     @classmethod
-    def set_auto_when_line_full(
-        cls: Type[Self], settings: SoftwareSwitches, enabled: bool
-    ) -> Tuple[SoftwareSwitches, Command]:
+    def set_auto_when_line_full(cls: Type[Self], enabled: bool) -> Command:
         """
         Configure the automatic insertion of a line feed when the line is full,
         as per page 34 of the ImageWriter II Technical Reference Manual.
@@ -223,15 +214,10 @@ class LineFeedEncoder:
 
         cmd_cls = CloseSoftwareSwitches if enabled else OpenSoftwareSwitches
 
-        return (
-            dataclasses.replace(settings, lf_when_line_full=enabled),
-            cmd_cls({SoftwareSwitch.LF_WHEN_LINE_FULL}),
-        )
+        return cmd_cls({SoftwareSwitch.LF_WHEN_LINE_FULL})
 
 
-def set_perforation_skip(
-    settings: SoftwareSwitches, enabled: bool
-) -> Tuple[SoftwareSwitches, Command]:
+def set_perforation_skip(enabled: bool) -> Command:
     """
     Configure automatic perforation skip, as per page 34 of the ImageWriter II
     Technical Reference Manual.
@@ -239,7 +225,4 @@ def set_perforation_skip(
 
     cmd_cls = OpenSoftwareSwitches if enabled else CloseSoftwareSwitches
 
-    return (
-        dataclasses.replace(settings, perforation_skip_disabled=not enabled),
-        cmd_cls({SoftwareSwitch.PERFORATION_SKIP_DISABLED}),
-    )
+    return cmd_cls({SoftwareSwitch.PERFORATION_SKIP_DISABLED})

--- a/imagewriter/encoding/print.py
+++ b/imagewriter/encoding/print.py
@@ -1,14 +1,9 @@
-import dataclasses
-from typing import Tuple
-
 from imagewriter.encoding.base import Command
 from imagewriter.encoding.switch import CloseSoftwareSwitches, OpenSoftwareSwitches
-from imagewriter.switch import SoftwareSwitch, SoftwareSwitches
+from imagewriter.switch import SoftwareSwitch
 
 
-def set_print_commands_include_lf_ff(
-    settings: SoftwareSwitches, enabled: bool
-) -> Tuple[SoftwareSwitches, Command]:
+def set_print_commands_include_lf_ff(enabled: bool) -> Command:
     """
     Configure the treatment of LF and FF as print commands, as per page 34
     of the ImageWriter II Technical Reference Manual.
@@ -16,7 +11,4 @@ def set_print_commands_include_lf_ff(
 
     cmd_cls = CloseSoftwareSwitches if enabled else OpenSoftwareSwitches
 
-    return (
-        dataclasses.replace(settings, print_commands_include_lf_ff=enabled),
-        cmd_cls({SoftwareSwitch.PRINT_COMMANDS_INCLUDE_LF_FF}),
-    )
+    return cmd_cls({SoftwareSwitch.PRINT_COMMANDS_INCLUDE_LF_FF})

--- a/imagewriter/encoding/select.py
+++ b/imagewriter/encoding/select.py
@@ -15,20 +15,15 @@ them, open the "software select response" software switch.
 See page 87 of the ImageWriter II Technical Reference Manual for more details.
 """
 
-import dataclasses
-from typing import Tuple
-
 from imagewriter.encoding.base import Command, Ctrl
 from imagewriter.encoding.switch import CloseSoftwareSwitches, OpenSoftwareSwitches
-from imagewriter.switch import SoftwareSwitch, SoftwareSwitches
+from imagewriter.switch import SoftwareSwitch
 
 SELECT = Ctrl("Q")
 DESELECT = Ctrl("S")
 
 
-def set_software_select_response(
-    settings: SoftwareSwitches, enabled: bool
-) -> Tuple[SoftwareSwitches, Command]:
+def set_software_select_response(enabled: bool) -> Command:
     """
     Configure Software Select-Deselect Response, as per page 34 of the
     ImageWriter II Technical Reference Manual.
@@ -36,7 +31,4 @@ def set_software_select_response(
 
     cmd_cls = OpenSoftwareSwitches if enabled else CloseSoftwareSwitches
 
-    return (
-        dataclasses.replace(settings, software_select_response_disabled=not enabled),
-        cmd_cls({SoftwareSwitch.SOFTWARE_SELECT_RESPONSE_DISABLED}),
-    )
+    return cmd_cls({SoftwareSwitch.SOFTWARE_SELECT_RESPONSE_DISABLED})

--- a/imagewriter/encoding/serial.py
+++ b/imagewriter/encoding/serial.py
@@ -1,52 +1,19 @@
-import dataclasses
-from typing import Tuple
-
-from imagewriter.encoding.base import Command
 from imagewriter.encoding.switch import CloseSoftwareSwitches, OpenSoftwareSwitches
-from imagewriter.switch import SoftwareSwitch, SoftwareSwitches
+from imagewriter.switch import SoftwareSwitch
 
+"""
+Ignore or respect the eighth data bit of each byte sent, as per page 34 of the
+ImageWriter II Technical Reference Manual.
 
-def ignore_eighth_data_bit(
-    settings: SoftwareSwitches,
-) -> Tuple[SoftwareSwitches, Command]:
-    """
-    Ignore the eighth data bit of each byte sent, as per page 34 of the
-    ImageWriter II Technical Reference Manual.
+This setting is for the benefit of Applesoft Basic, which does not
+support an eighth bit. Pure ASCII does not use the eighth bit, and the
+ImageWriter II supports escape sequences for "high-ASCII", as per
+Chapter 4 and Chapter 7 of the manual.
 
-    This setting is for the benefit of Applesoft Basic, which does not
-    support an eighth bit. Pure ASCII does not use the eighth bit, and the
-    ImageWriter II supports escape sequences for "high-ASCII", as per
-    Chapter 4 and Chapter 7 of the manual.
+Note that the ImageWriter II will automatically switch to 8-bit mode
+when an escape sequence sent to it uses 8-bit data - examples include
+custom characters and graphics.
+"""
 
-    Note that the ImageWriter II will automatically switch to 8-bit mode
-    when an escape sequence sent to it uses 8-bit data - examples include
-    custom characters and graphics.
-    """
-
-    return (
-        dataclasses.replace(settings, ignore_eighth_data_bit=True),
-        CloseSoftwareSwitches({SoftwareSwitch.IGNORE_EIGHTH_DATA_BIT}),
-    )
-
-
-def include_eighth_data_bit(
-    settings: SoftwareSwitches,
-) -> Tuple[SoftwareSwitches, Command]:
-    """
-    Include the eighth data bit of each byte sent, as per page 34 of the
-    ImageWriter II Technical Reference Manual.
-
-    This setting is for the benefit of Applesoft Basic, which does not
-    support an eighth bit. Pure ASCII does not use the eighth bit, and the
-    ImageWriter II supports escape sequences for "high-ASCII", as per
-    Chapter 4 and Chapter 7 of the manual.
-
-    Note that the ImageWriter II will automatically switch to 8-bit mode
-    when an escape sequence sent to it uses 8-bit data - examples include
-    custom characters and graphics.
-    """
-
-    return (
-        dataclasses.replace(settings, ignore_eighth_data_bit=False),
-        OpenSoftwareSwitches({SoftwareSwitch.IGNORE_EIGHTH_DATA_BIT}),
-    )
+IGNORE_EIGHTH_DATA_BIT = CloseSoftwareSwitches({SoftwareSwitch.IGNORE_EIGHTH_DATA_BIT})
+INCLUDE_EIGHTH_DATA_BIT = OpenSoftwareSwitches({SoftwareSwitch.IGNORE_EIGHTH_DATA_BIT})

--- a/imagewriter/state.py
+++ b/imagewriter/state.py
@@ -1,3 +1,4 @@
+import dataclasses
 from typing import Optional, Self
 
 from imagewriter.color import Color
@@ -76,33 +77,85 @@ class State:
     def language(self: Self) -> Language:
         return self.software_switches.language
 
+    @language.setter
+    def language(self: Self, language: Language) -> None:
+        self.software_switches = dataclasses.replace(
+            self.software_switches, language=language
+        )
+
     @property
     def software_select_response(self: Self) -> bool:
         return not self.software_switches.software_select_response_disabled
+
+    @software_select_response.setter
+    def software_select_response(self: Self, software_select_response: bool) -> None:
+        self.software_switches = dataclasses.replace(
+            self.software_switches,
+            software_select_response_disabled=not software_select_response,
+        )
 
     @property
     def lf_when_line_full(self: Self) -> bool:
         return self.software_switches.lf_when_line_full
 
+    @lf_when_line_full.setter
+    def lf_when_line_full(self: Self, lf_when_line_full: bool) -> None:
+        self.software_switches = dataclasses.replace(
+            self.software_switches, lf_when_line_full=lf_when_line_full
+        )
+
     @property
     def print_commands_include_lf_ff(self: Self) -> bool:
         return self.software_switches.print_commands_include_lf_ff
+
+    @print_commands_include_lf_ff.setter
+    def print_commands_include_lf_ff(
+        self: Self, print_commands_include_lf_ff: bool
+    ) -> None:
+        self.software_switches = dataclasses.replace(
+            self.software_switches,
+            print_commands_include_lf_ff=print_commands_include_lf_ff,
+        )
 
     @property
     def auto_lf_after_cr(self: Self) -> bool:
         return self.software_switches.auto_lf_after_cr
 
+    @auto_lf_after_cr.setter
+    def auto_lf_after_cr(self: Self, auto_lf_after_cr: bool) -> None:
+        self.software_switches = dataclasses.replace(
+            self.software_switches, auto_lf_after_cr=auto_lf_after_cr
+        )
+
     @property
     def slashed_zero(self: Self) -> bool:
         return self.software_switches.slashed_zero
+
+    @slashed_zero.setter
+    def slashed_zero(self: Self, slashed_zero: bool) -> None:
+        self.software_switches = dataclasses.replace(
+            self.software_switches, slashed_zero=slashed_zero
+        )
 
     @property
     def perforation_skip(self: Self) -> bool:
         return not self.software_switches.perforation_skip_disabled
 
+    @perforation_skip.setter
+    def perforation_skip(self: Self, perforation_skip: bool) -> None:
+        self.software_switches = dataclasses.replace(
+            self.software_switches, perforation_skip=perforation_skip
+        )
+
     @property
     def ignore_eighth_data_bit(self: Self) -> bool:
         return self.software_switches.ignore_eighth_data_bit
+
+    @ignore_eighth_data_bit.setter
+    def ignore_eighth_data_bit(self: Self, ignore_eighth_data_bit: bool) -> None:
+        self.software_switches = dataclasses.replace(
+            self.software_switches, ignore_eighth_data_bit=ignore_eighth_data_bit
+        )
 
     # boundaries
     @property


### PR DESCRIPTION
I wanted to track software switch changes as a response to encoding changes, as per #3. But the state tracking paradigm in #4 generally decouples state from encoding, with the expectation that the caller will track the state after submitting the relevant command. Therefore, switch related encoding is no longer aware of the `SoftwareSwitches` object.

Note that, if a command is created and a command is canceled, then the state will need to be reverted. One way to solve that is to use a visitor pattern in the command. The benefit is that I won't need a big if/else block to do the correct revert. But, on the other hand, that would once again couple state to encoding. I haven't decided which direction I want to go yet - but we'll cross that bridge later.

In the meantime, this change is submitted as a PR that I can easily revert.