### PR TITLE
Transactions

### DIFF
--- a/imagewriter/transactions.py
+++ b/imagewriter/transactions.py
@@ -1,0 +1,25 @@
+from typing import Callable, Dict, Self, Sequence
+
+from imagewriter.encoding.base import Command
+from imagewriter.state import State
+
+RevertFn = Callable[[State]]
+
+
+class TransactionManager:
+    def __init__(self: Self, state: State) -> None:
+        self.state: State = state
+        self._transactions: Dict[Command, RevertFn] = dict()
+
+    def start_command(self: Self, command: Command, revert: RevertFn) -> None:
+        self._transactions[command] = revert
+
+    def complete_command(self: Self, command: Command) -> None:
+        del self._transactions[command]
+
+    def rollback(self: Self, commands: Sequence[Command]) -> None:
+        for command in commands:
+            if command in self._transactions:
+                self._transactions[command](self.state)
+
+        self._transactions = dict()


### PR DESCRIPTION
Currently, my intent is to update state as soon as a command is passed to the connection. But those commands will also buffer asynchronously, based on the value of DTR, with the ability to interrupt in-flight commands with a reset of some kind.

One way I can do this is to simply execute the reset, and on completion revert all changes staged in the buffer. I decided to sketch that out in this Transaction class.

Another way I can do it is to execute the reset, reset state to sensible defaults, and execute the commands necessary to handle the ensuing drift (force software switches, etc). This mechanism may be more sensible.