### PR TITLE
Do not track transient states

### DIFF
--- a/imagewriter/state.py
+++ b/imagewriter/state.py
@@ -1,7 +1,6 @@
 import dataclasses
 from typing import Optional, Self
 
-from imagewriter.color import Color
 from imagewriter.language import Language
 from imagewriter.motion import LineFeedDirection, LinesPerInch, TabStops
 from imagewriter.pitch import Pitch
@@ -28,20 +27,9 @@ class State:
             else SoftwareSwitches.defaults(self.dip_switches)
         )
 
-        # attributes
-        self.double_width: bool = False
-        self.underline: bool = False
-        self.boldface: bool = False
-        self.half_height: bool = False
-        self.superscript: bool = False
-        self.subscript: bool = False
-
         # boundaries
         self._left_margin: Distance = Inch(0)
         self._page_length: Distance = Inch(self.dip_switches.form_length)
-
-        # color
-        self.color: Color = Color.BLACK
 
         # insertion
         self.carriage_return_insertion: bool = False


### PR DESCRIPTION
Currently, I treat language, slashed_zero, mousetext mode, etc. as "transient states" from the perspective of encoding, with defaults tracked in state. This is inconsistent with the idea of tracking attributes (underline, boldface) and color in state. In fact, tracking color is problematic, since it will also change in a highly transient manner when rendering images.

Therefore, I removed these properties from state, with the assumption that, in an interrupt scenario, they would reset to their defaults.

Submitting this as a PR to track the decision, and to make it easy to revert later if I change my mind.