### PR TITLE
Connection refactor

### DIFF
--- a/imagewriter.ipynb
+++ b/imagewriter.ipynb
@@ -2,43 +2,144 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 11,
    "id": "a27f4688-b19d-40ae-995f-3881cfa4fdf2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from concurrent.futures import ThreadPoolExecutor\n",
+    "import queue\n",
+    "from threading import Lock\n",
+    "\n",
+    "executor = ThreadPoolExecutor()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "abcda238-b3a4-42e8-bbd3-b676fc810974",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def write(text):\n",
+    "    print(text)\n",
+    "    return \"salad\"\n",
+    "\n",
+    "fut = executor.submit(write, \"foo\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "70bfa93b-b2f0-4f50-89cc-b3dbda1ef70d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'salad'"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "fut.result()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "99c102f3-042d-49c8-b75e-ac06d5e9c9c2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Connection:\n",
+    "    def __init__(self):\n",
+    "        self.lock = Lock()\n",
+    "        \n",
+    "    def write(self, command):\n",
+    "        return executor.submit(self._write, command)\n",
+    "\n",
+    "    def interrupt(self, command):\n",
+    "        return executor.submit(self._interrupt, command)\n",
+    "\n",
+    "    def _write(self, command):\n",
+    "        print(\"command:\", command)\n",
+    "        return 1\n",
+    "\n",
+    "    def _interrupt(self, command):\n",
+    "        print(\"interrupt:\", command)\n",
+    "        return 1\n",
+    "\n",
+    "connection = Connection()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "3b27b71f-b491-4fc5-a9a2-3fdbed20c276",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "on_print method called\n"
+      "command: foo\n"
      ]
     },
     {
      "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "ea86c8ab6d2241e6b34ee00006311420",
-       "version_major": 2,
-       "version_minor": 0
-      },
       "text/plain": [
-       "ControlPanel(children=(VBox(children=(HTML(value='<h3>Serial Connection</h3>'), SerialWidget(children=(SerialP…"
+       "1"
       ]
      },
-     "execution_count": 1,
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "interrupt: foo\n"
+     ]
+    }
+   ],
+   "source": [
+    "connection.write(\"foo\").result()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "6d59eb82-209e-4f3d-860c-6d40dfdd1c38",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "import logging\n",
-    "\n",
-    "from imagewriter.widgets import ControlPanel\n",
-    "\n",
-    "logging.basicConfig()\n",
-    "\n",
-    "control = ControlPanel()\n",
-    "control"
+    "connection.interrupt(\"foo\").result()"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2831cf4a-43e0-460a-be9d-c4bb3ff5d397",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -57,7 +158,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.7"
+   "version": "3.14.0"
   }
  },
  "nbformat": 4,

--- a/imagewriter/connection.py
+++ b/imagewriter/connection.py
@@ -1,8 +1,9 @@
-from concurrent.futures import Executor, ThreadPoolExecutor
+from abc import ABC, abstractmethod
+from concurrent.futures import Executor
 import logging
 import queue
 import time
-from typing import List, Self, Sequence
+from typing import Any, Callable, List, Optional, Self, Sequence
 
 from imagewriter.encoding import Command
 from imagewriter.serial import Serial, SerialProtocol
@@ -10,138 +11,284 @@ from imagewriter.serial import Serial, SerialProtocol
 logger = logging.getLogger(__name__)
 
 
-class Interrupt:
-    def __init__(self: Self, commands: List[Command], dump: bool) -> None:
-        self.commands: List[Command] = commands
-        self.dump: bool = dump
+class Request(queue.Queue[Any], ABC):
+    def __init__(self: Self, command: Any) -> None:
+        self.command = command
 
-
-class Interrupted(Exception):
-    def __init__(self: Self, dump: bool) -> None:
-        super().__init__(f"Interrupted(dump={dump})")
-        self.dump = dump
-
-
-class Connection:
-    def __init__(self: Self, serial: Serial) -> None:
-        self.serial: Serial = serial
-        self._executor: Executor = ThreadPoolExecutor()
-        self._command_queue: queue.Queue[Command] = queue.Queue(maxsize=0)
-        self._interrupt_queue: queue.Queue[Interrupt] = queue.Queue(maxsize=1)
-        self._error_queue: queue.Queue[Exception] = queue.Queue(maxsize=0)
-
-        self._running: bool = True
-        self._executor.submit(self._worker)
-
-    def shutdown(self: Self) -> None:
+    def result(self: Self, timeout: Optional[float] = None) -> Any:
         """
-        Shut down the background worker.
+        Get the result of a request. Blocks until results are complete,
+        barring a timeout.
         """
 
-        self._running = False
-        self._executor.shutdown()
+        res = self.get(timeout=timeout)
 
-    def write(self: Self, commands: Sequence[Command]) -> None:
-        """
-        Write to the serial portl.
+        if isinstance(res, Exception):
+            raise res
 
-        Commands are buffered, respecting the ImageWriter II's CTS signal.
-        """
+        return res
 
-        for command in commands:
-            self._command_queue.put(command)
 
-    def flush(self: Self) -> None:
-        self.serial.flush()
+class WriteRequest(Request):
+    """
+    A request to write a Command.
+    """
+
+    pass
+
+
+class FlushRequest(Request):
+    """
+    A request to flush the connection.
+    """
+
+    def __init__(self: Self) -> None:
+        super().__init__(None)
+
+
+class InterruptRequest(Request):
+    """
+    A request to interrupt with multiple commands.
+    """
+
+    pass
+
+
+class Response(ABC):
+    @abstractmethod
+    def result(self: Self, timeout: Optional[float] = None) -> Any:
+        raise NotImplementedError("Response.result")
+
+
+class WriteResponse(Response):
+    """
+    A response to a write request.
+    """
+
+    def __init__(self: Self, requests: Sequence[Request]) -> None:
+        self._requests = requests
+
+    def result(self: Self, timeout: Optional[float] = None) -> Any:
+        count: Optional[int] = None
+
+        for req in self._requests:
+            res = req.result(timeout=timeout)
+            if res is not None:
+                if count is None:
+                    count = 0
+                count += res
+
+        return count
+
+
+class InterruptResponse(Response):
+    """
+    A response to an interrupt request.
+    """
+
+    def __init__(self: Self, request: InterruptRequest) -> None:
+        self._request = request
+
+    def result(self: Self, timeout: Optional[float] = None) -> Any:
+        count: Optional[int] = None
+
+        for res in self._request.result(timeout=timeout):
+            if res is not None:
+                if count is None:
+                    count = 0
+                count += res
+
+        return count
+
+
+class InterruptError(Exception):
+    """
+    An exception raised when a command is interrupted.
+    """
+
+    pass
+
+
+def _get_request(connection: "Connection") -> Request:
+    """
+    Get the next request, respecting interrupts.
+    """
+
+    try:
+        return connection._interrupt_queue.get_nowait()
+    except queue.Empty:
+        pass
+
+    req = connection._request_queue.get()
+
+    while not connection.serial.cts:
         try:
-            exc = self._error_queue.get_nowait()
-            raise exc
+            return connection._interrupt_queue.get_nowait()
         except queue.Empty:
             pass
 
-    def interrupt(self: Self, commands: Sequence[Command], dump: bool = True) -> None:
-        """
-        Interrupt with a sequence of commands.
+        time.sleep(1 / connection.serial.baudrate)
 
-        Interrupts are run before any in-flight commands, and ignore the
-        ImageWriter II's CTS line.
-        """
+    return req
 
-        self._interrupt_queue.put_nowait(Interrupt(commands=list(commands), dump=dump))
 
-    @property
-    def _timeout(self: Self) -> float:
-        return 1 / self.serial.baudrate
+def _get_request_nowait(connection: "Connection") -> Request:
+    """
+    Get the next request if available, respecting interrupts. Do not wait for
+    CTS to be asserted.
+    """
 
-    def _worker(self: Self) -> None:
-        try:
-            while self._running:
+    req = connection._request_queue.get_nowait()
+
+    try:
+        return connection._interrupt_queue.get_nowait()
+    except queue.Empty:
+        pass
+
+    return req
+
+
+def _write(connection: "Connection", request: WriteRequest) -> None:
+    """
+    Write a command to the serial port.
+    """
+
+    res = connection.serial.write(bytes(request.command))
+    request.put(res)
+
+
+def _flush(connection: "Connection", request: FlushRequest) -> None:
+    """
+    Write any remaining commands, and flush the connection.
+    """
+
+    requests: List[FlushRequest] = [request]
+
+    try:
+        while True:
+            req = _get_request_nowait(connection)
+            if isinstance(req, FlushRequest):
+                requests.append(req)
+            else:
+                assert isinstance(req, WriteRequest)
+                res = _write(connection, req)
+                req.put(res)
+    except queue.Empty:
+        pass
+    except Exception as exc:
+        for req in requests:
+            req.put(exc)
+        for req in _dump(connection):
+            req.put(exc)
+        return
+
+    connection.flush()
+
+    for req in requests:
+        req.put(None)
+
+
+def _interrupt(connection: "Connection", request: InterruptRequest) -> None:
+    """
+    Temporarily disable flow control, run interrupt commands, and dump the
+    remaining commands.
+    """
+
+    try:
+        connection.set_flow_control(False)
+
+        result = [
+            connection.serial.write(bytes(command)) for command in request.command
+        ]
+
+        connection.serial.flush()
+
+        connection.set_flow_control(True)
+
+        for res in _dump(connection):
+            res.put(InterruptError(f"Command was interrupted with: {request.command}"))
+    except Exception as exc:
+        request.put(exc)
+    else:
+        request.put(result)
+
+
+def _dump(connection: "Connection") -> List[Request]:
+    """
+    Dump and return remaining requests.
+    """
+
+    requests: List[Request] = list()
+
+    try:
+        while True:
+            req = connection._request_queue.get_nowait()
+            requests.append(req)
+    except queue.Empty:
+        pass
+
+    return requests
+
+
+def _worker(connection: "Connection") -> Callable[[], None]:
+    def worker() -> None:
+        while connection._running:
+            try:
+                request = _get_request(connection)
+
                 try:
-                    # Check for interrupts
-                    self._run_interrupts()
-                    try:
-                        # Fetch the command
-                        command = self._command_queue.get(timeout=self._timeout)
-                        # Check for interrupts again
-                        self._run_interrupts()
-                        # Wait for CTS to go high
-                        self._wait_for_cts()
-                        # Now we can write the command
-                        self.serial.write(bytes(command))
-                    except queue.Empty:
-                        # No ready command - that's OK
-                        continue
-                except Interrupted as exc:
-                    # Dump the command queue if need be
-                    if exc.dump:
-                        self._dump()
-                    pass
-        except Exception as exc:
-            logger.error(exc)
-            self._error_queue.put(exc)
+                    if isinstance(request, InterruptRequest):
+                        _interrupt(connection, request)
+                    elif isinstance(request, FlushRequest):
+                        _flush(connection, request)
+                    else:
+                        assert isinstance(request, WriteRequest)
+                        _write(connection, request)
+                except Exception as exc:
+                    request.put(exc)
+            except queue.Empty:
+                # No ready command - that's OK
+                continue
+            except Exception as exc:
+                logger.error(exc)
 
-    def _wait_for_cts(self: Self) -> None:
-        # Check for interrupts until CTS is high
-        while not self.serial.cts:
-            time.sleep(self._timeout)
-            self._run_interrupts()
-        # Check for interrupts one last time
-        self._run_interrupts()
+    return worker
 
-    def _set_flow_control(self: Self, enabled: bool) -> None:
+
+class Connection:
+    def __init__(self: Self, serial: Serial, executor: Executor) -> None:
+        self.serial: Serial = serial
+        self._executor: Executor = executor
+        self._request_queue: queue.Queue[Request] = queue.Queue(maxsize=0)
+        self._interrupt_queue: queue.Queue[InterruptRequest] = queue.Queue()
+
+        self._running: bool = True
+        self._executor.submit(_worker(self))
+
+    def write(self: Self, commands: Sequence[Command]) -> WriteResponse:
+        requests = [WriteRequest(command) for command in commands]
+
+        for req in requests:
+            self._request_queue.put(req)
+
+        return WriteResponse(requests)
+
+    def interrupt(self: Self, commands: Sequence[Command]) -> Response:
+        interrupt = InterruptRequest(list(commands))
+        self._interrupt_queue.put_nowait(interrupt)
+
+        return InterruptResponse(interrupt)
+
+    def flush(self: Self) -> None:
+        req = FlushRequest()
+        self._request_queue.put(req)
+        return req.result()
+
+    def set_flow_control(self: Self, enabled: bool) -> None:
         if self.serial.protocol == SerialProtocol.XONXOFF:
             self.serial.xonxoff = enabled
         else:
             self.serial.rtscts = enabled
 
-    def _run_interrupts(self: Self) -> None:
-        try:
-            # Is there an interrupt?
-            interrupt = self._interrupt_queue.get_nowait()
-
-            # Disable flow control
-            self._set_flow_control(False)
-
-            # Write our interrupt to the serial
-            for command in interrupt.commands:
-                self.serial.write(bytes(command))
-
-            # Flush the serial
-            self.flush()
-
-            # Enable flow_control again
-            self._set_flow_control(True)
-
-            # Let the worker handle the cleanup
-            raise Interrupted(interrupt.dump)
-        except queue.Empty:
-            # No interrupt, keep on truckin'
-            pass
-
-    def _dump(self: Self) -> None:
-        # Pull from the command queue until exhausted
-        try:
-            while True:
-                self._command_queue.get_nowait()
-        except queue.Empty:
-            pass
+    def stop(self: Self) -> None:
+        self._running = False

--- a/imagewriter/connection.py
+++ b/imagewriter/connection.py
@@ -1,9 +1,9 @@
-from abc import ABC, abstractmethod
-from concurrent.futures import Executor
+from concurrent.futures import Executor, Future
 import logging
 import queue
+from threading import Lock
 import time
-from typing import Any, Callable, List, Optional, Self, Sequence
+from typing import List, Optional, Self, Sequence, Tuple
 
 from imagewriter.encoding import Command
 from imagewriter.serial import Serial, SerialProtocol
@@ -11,284 +11,82 @@ from imagewriter.serial import Serial, SerialProtocol
 logger = logging.getLogger(__name__)
 
 
-class Request(queue.Queue[Any], ABC):
-    def __init__(self: Self, command: Any) -> None:
-        self.command = command
-
-    def result(self: Self, timeout: Optional[float] = None) -> Any:
-        """
-        Get the result of a request. Blocks until results are complete,
-        barring a timeout.
-        """
-
-        res = self.get(timeout=timeout)
-
-        if isinstance(res, Exception):
-            raise res
-
-        return res
-
-
-class WriteRequest(Request):
-    """
-    A request to write a Command.
-    """
-
+class ConnectionError(Exception):
     pass
 
 
-class FlushRequest(Request):
-    """
-    A request to flush the connection.
-    """
-
-    def __init__(self: Self) -> None:
-        super().__init__(None)
-
-
-class InterruptRequest(Request):
-    """
-    A request to interrupt with multiple commands.
-    """
-
+class InterruptError(ConnectionError):
     pass
 
 
-class Response(ABC):
-    @abstractmethod
-    def result(self: Self, timeout: Optional[float] = None) -> Any:
-        raise NotImplementedError("Response.result")
+InterruptRequest = Tuple[List[Command], Future[Optional[int]]]
 
 
-class WriteResponse(Response):
-    """
-    A response to a write request.
-    """
-
-    def __init__(self: Self, requests: Sequence[Request]) -> None:
-        self._requests = requests
-
-    def result(self: Self, timeout: Optional[float] = None) -> Any:
-        count: Optional[int] = None
-
-        for req in self._requests:
-            res = req.result(timeout=timeout)
-            if res is not None:
-                if count is None:
-                    count = 0
-                count += res
-
-        return count
-
-
-class InterruptResponse(Response):
-    """
-    A response to an interrupt request.
-    """
-
-    def __init__(self: Self, request: InterruptRequest) -> None:
-        self._request = request
-
-    def result(self: Self, timeout: Optional[float] = None) -> Any:
-        count: Optional[int] = None
-
-        for res in self._request.result(timeout=timeout):
-            if res is not None:
-                if count is None:
-                    count = 0
-                count += res
-
-        return count
-
-
-class InterruptError(Exception):
-    """
-    An exception raised when a command is interrupted.
-    """
-
-    pass
-
-
-def _get_request(connection: "Connection") -> Request:
-    """
-    Get the next request, respecting interrupts.
-    """
-
-    try:
-        return connection._interrupt_queue.get_nowait()
-    except queue.Empty:
-        pass
-
-    req = connection._request_queue.get()
-
-    while not connection.serial.cts:
-        try:
-            return connection._interrupt_queue.get_nowait()
-        except queue.Empty:
-            pass
-
-        time.sleep(1 / connection.serial.baudrate)
-
-    return req
-
-
-def _get_request_nowait(connection: "Connection") -> Request:
-    """
-    Get the next request if available, respecting interrupts. Do not wait for
-    CTS to be asserted.
-    """
-
-    req = connection._request_queue.get_nowait()
-
-    try:
-        return connection._interrupt_queue.get_nowait()
-    except queue.Empty:
-        pass
-
-    return req
-
-
-def _write(connection: "Connection", request: WriteRequest) -> None:
-    """
-    Write a command to the serial port.
-    """
-
-    res = connection.serial.write(bytes(request.command))
-    request.put(res)
-
-
-def _flush(connection: "Connection", request: FlushRequest) -> None:
-    """
-    Write any remaining commands, and flush the connection.
-    """
-
-    requests: List[FlushRequest] = [request]
-
-    try:
-        while True:
-            req = _get_request_nowait(connection)
-            if isinstance(req, FlushRequest):
-                requests.append(req)
-            else:
-                assert isinstance(req, WriteRequest)
-                res = _write(connection, req)
-                req.put(res)
-    except queue.Empty:
-        pass
-    except Exception as exc:
-        for req in requests:
-            req.put(exc)
-        for req in _dump(connection):
-            req.put(exc)
-        return
-
-    connection.flush()
-
-    for req in requests:
-        req.put(None)
-
-
-def _interrupt(connection: "Connection", request: InterruptRequest) -> None:
-    """
-    Temporarily disable flow control, run interrupt commands, and dump the
-    remaining commands.
-    """
-
-    try:
-        connection.set_flow_control(False)
-
-        result = [
-            connection.serial.write(bytes(command)) for command in request.command
-        ]
-
-        connection.serial.flush()
-
-        connection.set_flow_control(True)
-
-        for res in _dump(connection):
-            res.put(InterruptError(f"Command was interrupted with: {request.command}"))
-    except Exception as exc:
-        request.put(exc)
+def _add(a: Optional[int], b: Optional[int]) -> Optional[int]:
+    if a is None:
+        if b is None:
+            return None
+        return b
+    elif b is None:
+        return a
     else:
-        request.put(result)
-
-
-def _dump(connection: "Connection") -> List[Request]:
-    """
-    Dump and return remaining requests.
-    """
-
-    requests: List[Request] = list()
-
-    try:
-        while True:
-            req = connection._request_queue.get_nowait()
-            requests.append(req)
-    except queue.Empty:
-        pass
-
-    return requests
-
-
-def _worker(connection: "Connection") -> Callable[[], None]:
-    def worker() -> None:
-        while connection._running:
-            try:
-                request = _get_request(connection)
-
-                try:
-                    if isinstance(request, InterruptRequest):
-                        _interrupt(connection, request)
-                    elif isinstance(request, FlushRequest):
-                        _flush(connection, request)
-                    else:
-                        assert isinstance(request, WriteRequest)
-                        _write(connection, request)
-                except Exception as exc:
-                    request.put(exc)
-            except queue.Empty:
-                # No ready command - that's OK
-                continue
-            except Exception as exc:
-                logger.error(exc)
-
-    return worker
+        return a + b
 
 
 class Connection:
     def __init__(self: Self, serial: Serial, executor: Executor) -> None:
         self.serial: Serial = serial
         self._executor: Executor = executor
-        self._request_queue: queue.Queue[Request] = queue.Queue(maxsize=0)
-        self._interrupt_queue: queue.Queue[InterruptRequest] = queue.Queue()
+        self._command_lock = Lock()
+        self._interrupts: queue.Queue[InterruptRequest] = queue.Queue()
 
-        self._running: bool = True
-        self._executor.submit(_worker(self))
+    def write(self: Self, commands: Sequence[Command]) -> Future[Optional[int]]:
+        return self._executor.submit(self._write, commands)
 
-    def write(self: Self, commands: Sequence[Command]) -> WriteResponse:
-        requests = [WriteRequest(command) for command in commands]
+    def _write(self: Self, commands: Sequence[Command]) -> Optional[int]:
+        count: Optional[int] = 0
+        with self._command_lock:
+            for command in commands:
+                self._run_interrupts()
 
-        for req in requests:
-            self._request_queue.put(req)
+                while not self.serial.cts:
+                    time.sleep(1 / self.serial.baudrate)
+                    self._run_interrupts()
 
-        return WriteResponse(requests)
+                res = self.serial.write(bytes(command))
+                count = _add(count, res)
 
-    def interrupt(self: Self, commands: Sequence[Command]) -> Response:
-        interrupt = InterruptRequest(list(commands))
-        self._interrupt_queue.put_nowait(interrupt)
+            self.serial.flush()
+            return count
 
-        return InterruptResponse(interrupt)
+    def interrupt(self: Self, commands: Sequence[Command]) -> Future[Optional[int]]:
+        fut: Future[Optional[int]] = Future()
+        self._interrupts.put((list(commands), fut))
+        return fut
 
-    def flush(self: Self) -> None:
-        req = FlushRequest()
-        self._request_queue.put(req)
-        return req.result()
+    def _run_interrupts(self: Self) -> None:
+        count: Optional[int] = None
+        try:
+            interrupts, fut = self._interrupts.get_nowait()
 
-    def set_flow_control(self: Self, enabled: bool) -> None:
+            self._set_flow_control(False)
+
+            for command in interrupts:
+                res = self.serial.write(bytes(command))
+                count = _add(count, res)
+
+            self._set_flow_control(True)
+
+            self.serial.flush()
+
+            fut.set_result(count)
+
+            raise InterruptError()
+        except queue.Empty:
+            pass
+
+    def _set_flow_control(self: Self, enabled: bool) -> None:
         if self.serial.protocol == SerialProtocol.XONXOFF:
             self.serial.xonxoff = enabled
         else:
             self.serial.rtscts = enabled
-
-    def stop(self: Self) -> None:
-        self._running = False

--- a/imagewriter/container.py
+++ b/imagewriter/container.py
@@ -63,17 +63,6 @@ def provide_serial_state_observer(
     observer.stop()
 
 
-@contextmanager
-def provide_connection(
-    serial: Serial, executor: Executor
-) -> Generator[Connection, None, None]:
-    connection = Connection(serial=serial, executor=executor)
-
-    yield connection
-
-    connection.stop()
-
-
 class Container(containers.DeclarativeContainer):
     port = providers.Callable(provide_port)
 
@@ -95,10 +84,7 @@ class Container(containers.DeclarativeContainer):
             provide_serial_state_observer, serial=serial, executor=executor
         ),
     )
-    connection = cast(
-        providers.Resource[Connection],
-        providers.Resource(provide_connection, serial=serial, executor=executor),
-    )
+    connection = providers.Factory(Connection, serial=serial, executor=executor)
 
     map_mousetext = providers.Object(False)
     map_custom = providers.Object(False)

--- a/imagewriter/container.py
+++ b/imagewriter/container.py
@@ -1,7 +1,12 @@
+from concurrent.futures import Executor, ThreadPoolExecutor
+from contextlib import contextmanager
+from typing import cast, Generator
+
 from dependency_injector import containers, providers
 from serial.tools.list_ports import comports
 
 from imagewriter.connection import Connection
+from imagewriter.debug import SerialStateObserver
 from imagewriter.encoding.character import CharacterEncoder
 from imagewriter.language import Language
 from imagewriter.render import DocumentRenderer, PandocRenderer, RichTextBuilder
@@ -38,6 +43,37 @@ def provide_language(settings: Settings) -> Language:
     return settings.language
 
 
+@contextmanager
+def provide_executor() -> Generator[Executor, None, None]:
+    executor = ThreadPoolExecutor()
+
+    yield executor
+
+    executor.shutdown(wait=False, cancel_futures=True)
+
+
+@contextmanager
+def provide_serial_state_observer(
+    serial: Serial, executor: Executor
+) -> Generator[SerialStateObserver, None, None]:
+    observer = SerialStateObserver(serial=serial, executor=executor)
+
+    yield observer
+
+    observer.stop()
+
+
+@contextmanager
+def provide_connection(
+    serial: Serial, executor: Executor
+) -> Generator[Connection, None, None]:
+    connection = Connection(serial=serial, executor=executor)
+
+    yield connection
+
+    connection.stop()
+
+
 class Container(containers.DeclarativeContainer):
     port = providers.Callable(provide_port)
 
@@ -48,10 +84,21 @@ class Container(containers.DeclarativeContainer):
     settings = providers.Callable(provide_settings, dip_switches=dip_switches)
     language = providers.Callable(provide_language, settings=settings)
 
+    executor = cast(providers.Resource[Executor], providers.Resource(provide_executor))
+
     serial = providers.Factory(
         Serial, port=port, baud_rate=baud_rate, protocol=protocol
     )
-    connection = providers.Factory(Connection, serial=serial)
+    serial_state_observer = cast(
+        providers.Resource[SerialStateObserver],
+        providers.Resource(
+            provide_serial_state_observer, serial=serial, executor=executor
+        ),
+    )
+    connection = cast(
+        providers.Resource[Connection],
+        providers.Resource(provide_connection, serial=serial, executor=executor),
+    )
 
     map_mousetext = providers.Object(False)
     map_custom = providers.Object(False)

--- a/imagewriter/debug.py
+++ b/imagewriter/debug.py
@@ -1,4 +1,4 @@
-from concurrent.futures import Executor, ThreadPoolExecutor
+from concurrent.futures import Executor
 import datetime
 import time
 from typing import Optional, Self
@@ -7,9 +7,9 @@ from serial import Serial
 
 
 class SerialStateObserver:
-    def __init__(self: Self, serial: Serial) -> None:
+    def __init__(self: Self, serial: Serial, executor: Executor) -> None:
         self.serial: Serial = serial
-        self._executor: Executor = ThreadPoolExecutor(max_workers=1)
+        self._executor: Executor = executor
         self._tick: float = 0.25 / serial.baudrate
         self.running: bool = False
 
@@ -65,7 +65,3 @@ class SerialStateObserver:
 
     def stop(self: Self) -> None:
         self.running = False
-
-    def shutdown(self: Self) -> None:
-        self.stop()
-        self._executor.shutdown()

--- a/imagewriter/test/memory.py
+++ b/imagewriter/test/memory.py
@@ -5,7 +5,6 @@ from imagewriter.serial import Serial
 
 def test_memory(serial: Serial, connection: Connection, print_buffer_size: int) -> int:
     connection.write([SetLFWhenLineFull(False), CR])
-    connection.flush()
 
     i = 0
 
@@ -14,6 +13,5 @@ def test_memory(serial: Serial, connection: Connection, print_buffer_size: int) 
         i += 1
 
     connection.interrupt([CANCEL_CURRENT_LINE, CR])
-    connection.flush()
 
     return i

--- a/imagewriter/widgets/activity.py
+++ b/imagewriter/widgets/activity.py
@@ -1,3 +1,4 @@
+from concurrent.futures import Executor
 from typing import Any, Optional, Self
 
 import ipywidgets as widgets
@@ -42,12 +43,14 @@ class WriteStatsWidget(widgets.HBox):
 
 
 class SerialStateObserver(debug.SerialStateObserver):
-    def __init__(self: Self, serial: Serial, widget: "ActivityWidget") -> None:
+    def __init__(
+        self: Self, serial: Serial, executor: Executor, widget: "ActivityWidget"
+    ) -> None:
         self._widget = widget
 
         self._write_hook(serial)
 
-        super().__init__(serial)
+        super().__init__(serial, executor)
 
     def _on_write(self: Self, data: Any) -> None:
         self._widget.write_stats.on_write(data)
@@ -89,9 +92,11 @@ class ActivityWidget(widgets.VBox):
 
         self._observer: Optional[SerialStateObserver] = None
 
-    def instrument(self: Self, serial: Serial) -> None:
+    def instrument(self: Self, serial: Serial, executor: Executor) -> None:
         self._reset()
-        self._observer = SerialStateObserver(serial=serial, widget=self)
+        self._observer = SerialStateObserver(
+            serial=serial, executor=executor, widget=self
+        )
         self.start()
 
     def _reset(self: Self) -> None:
@@ -112,6 +117,4 @@ class ActivityWidget(widgets.VBox):
             self._observer.stop()
 
     def shutdown(self: Self) -> None:
-        if self._observer:
-            self._observer.shutdown()
-            self._observer = None
+        self._observer = None

--- a/imagewriter/widgets/control.py
+++ b/imagewriter/widgets/control.py
@@ -1,4 +1,6 @@
-from typing import Optional, Self, Type
+from concurrent.futures import Executor
+from contextlib import contextmanager
+from typing import cast, Generator, Optional, Self, Type
 
 from dependency_injector import providers
 import ipywidgets as widgets
@@ -7,7 +9,7 @@ from imagewriter.connection import Connection
 from imagewriter.container import Container
 from imagewriter.serial import Serial
 from imagewriter.settings import Settings
-from imagewriter.widgets.activity import ActivityWidget
+from imagewriter.widgets.activity import ActivityWidget, SerialStateObserver
 from imagewriter.widgets.base import header
 from imagewriter.widgets.form_feed import TopOfFormWidget
 from imagewriter.widgets.serial import SerialWidget
@@ -65,8 +67,18 @@ class ControlPanel(widgets.Tab):
         self._test_widget.on_memory_test(self._run_memory_test)
 
     def _bind_cls(self: Self, cls: Type[Container]) -> Type[Container]:
+
         class Container(cls):
             serial = providers.Callable(self._provide_serial)
+
+            serial_state_observer = cast(
+                providers.Resource[SerialStateObserver],
+                providers.Resource(
+                    self._provide_serial_state_observer,
+                    serial=serial,
+                    executor=cls.executor,
+                ),
+            )
 
             connection = providers.Singleton(Connection, serial=serial)
 
@@ -84,11 +96,23 @@ class ControlPanel(widgets.Tab):
                 self._serial_widget.error(exc)
                 raise exc
 
-            self._activity_widget.instrument(self._serial)
+            self._activity_widget.instrument(self._serial, self.container.executor())
             if self._serial.is_open:
                 self._serial_widget.connect()
 
         return self._serial
+
+    @contextmanager
+    def _provide_serial_state_observer(
+        self: Self, serial: Serial, executor: Executor
+    ) -> Generator[SerialStateObserver, None, None]:
+        observer = SerialStateObserver(
+            serial=serial, executor=executor, widget=self._activity_widget
+        )
+
+        yield observer
+
+        observer.stop()
 
     @property
     def settings(self: Self) -> Settings:

--- a/imagewriter/widgets/form_feed.py
+++ b/imagewriter/widgets/form_feed.py
@@ -53,7 +53,6 @@ class TopOfFormWidget(widgets.HBox):
         self._status_widget.running()
         try:
             connection.write([SET_TOP_OF_FORM])
-            connection.flush()
         except Exception as exc:
             self._status_widget.error(exc)
             raise exc

--- a/imagewriter/widgets/test.py
+++ b/imagewriter/widgets/test.py
@@ -100,11 +100,7 @@ class TestWidget(widgets.VBox):
     ) -> None:
         self._test_page_status_widget.running()
         try:
-            for cmd in test_page:
-                connection.serial.write(bytes(cmd))
-
-            # connection.write(test_page)
-            connection.flush()
+            connection.write(test_page).result()
         except Exception as exc:
             self._test_page_status_widget.error(exc)
             raise exc

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,16 +113,16 @@ def container(port, serial) -> Generator[Container, None, None]:
 
     with container.port.override(port):
         with container.serial.override(serial):
+            container.init_resources()
+
             yield container
+
+            container.shutdown_resources()
 
 
 @pytest.fixture
-def connection(container: Container) -> Generator[Connection, None, None]:
-    connection = container.connection()
-
-    yield connection
-
-    connection.shutdown()
+def connection(container: Container) -> Connection:
+    return container.connection()
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,8 +68,8 @@ class MockSerial(Serial):
         self._xonxoff: bool = protocol == SerialProtocol.XONXOFF
 
         # Mocked methods
-        self.write = Mock(name="Serial().write")
-        self.flush = Mock(name="Serial().flush")
+        self.write = Mock(name="Serial().write", return_value=1)
+        self.flush = Mock(name="Serial().flush", return_value=1)
 
     @property
     def cts(self: Self) -> bool:

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,32 +1,24 @@
-import time
 from typing import Any
-from unittest.mock import call
 
-from imagewriter.connection import Connection
+import pytest
+
+from imagewriter.connection import Connection, InterruptError
 from imagewriter.encoding.base import Print
 
 
 def test_connection(serial: Any, connection: Connection) -> None:
-    def sleep(n: int | float) -> None:
-        time.sleep(2 * n / connection.serial.baudrate)
-
     first = Print(b"first")
     second = Print(b"second")
     interrupt = Print(b"interrupt")
 
-    connection.write([first])
-
-    sleep(1)
+    connection.write([first]).result()
 
     serial.cts = False
 
-    print("writing again")
-    connection.write([second])
-    print("interrupt")
-    connection.interrupt([interrupt])
+    interrupt_fut = connection.interrupt([interrupt])
+    write_fut = connection.write([second])
 
-    sleep(2)
+    interrupt_fut.result()
 
-    print("assert time")
-
-    serial.write.assert_has_calls([call(bytes(first)), call(bytes(interrupt))])
+    with pytest.raises(InterruptError):
+        write_fut.result()

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -8,7 +8,7 @@ from imagewriter.encoding.base import Print
 
 def test_connection(serial: Any, connection: Connection) -> None:
     def sleep(n: int | float) -> None:
-        time.sleep(2 * n * connection._timeout)
+        time.sleep(2 * n / connection.serial.baudrate)
 
     first = Print(b"first")
     second = Print(b"second")
@@ -20,9 +20,13 @@ def test_connection(serial: Any, connection: Connection) -> None:
 
     serial.cts = False
 
+    print("writing again")
     connection.write([second])
+    print("interrupt")
     connection.interrupt([interrupt])
 
     sleep(2)
+
+    print("assert time")
 
     serial.write.assert_has_calls([call(bytes(first)), call(bytes(interrupt))])


### PR DESCRIPTION
I'm trying to refactor the Connection abstraction, which currently does not have good error handling.

It currently passes the existing test, but hangs. My guess is that a resource is being held open. Some judicious logging should help there.

But this may also not be the right way to do it. The current abstraction doesn't leverage futures in the executor at all - there's probably a way to use them to my advantage. There may also be a way to manage interrupts with a context manager - `with connection.paused()` or similar.